### PR TITLE
delete code that was hiding admin bar

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1533,9 +1533,3 @@ function switchboard_form_classes($form)
 {
 	echo 'switchboard-form';
 }
-
-/**
- * Disable the admin bar on front-end as it's useless with barba
- */
-
-add_filter('show_admin_bar', '__return_false');


### PR DESCRIPTION
I think you deleted the wrong code because the admin bar was still not showing. I removed that function at the very end of the functions.php file.